### PR TITLE
Contact Us Form Migration

### DIFF
--- a/_includes/JB/contact-us-form.html
+++ b/_includes/JB/contact-us-form.html
@@ -1,0 +1,318 @@
+{% comment %}<!--
+Contact Form.
+
+This file can be included on any page where the collaborative workspace 
+interest form should be displayed.  Currently it is a part of the stand alone 
+form page (/contact-us/).
+        
+-->{% endcomment %}
+
+<form name="cuForm" id="cuForm" method="POST">
+  <div class="row">
+    <div class="col-xs-12">
+      <h4>Stratify Labs New Client Contact Form</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <p>We are excited about the opportunity to help you bring your idea to market. Please fill out the form below so that we can get back to you as quickly as possible.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+    	<div class="form-legend">
+    		<span class="req">* Required</span>
+    	</div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+    	<div>
+    		<label for="emailAddress">Email Address <span class="req">*</span></label>
+    	</div>
+    	<div>
+        <input type="email" class="form-control" placeholder="Your email" id="emailAddress" name="emailAddress" required>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+    	<div>
+    		<label for="entry.1821144503">How did you hear about Stratify Labs? <span class="req">*</span></label>
+    	</div>
+    	<div>
+        <input type="text" class="form-control" placeholder="Your answer" id="entry.1821144503" name="entry.1821144503" required>
+      </div>
+    </div>
+  </div>
+  <div class="row form-subheader">
+    <div class="col-xs-12">
+      <div class="form-subheader-container" role="heading">
+        <div>Contact Info</div>
+      </div>
+      <div class="form-subheader-triangle">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 14 10" preserveAspectRatio="none">
+          <polygon class="freebirdSolidFill" points="0,0 13,0 0,13"></polygon>
+        </svg>
+      </div>
+    </div>
+  </div>  
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.1277414663">Name <span class="req">*</span></label>
+      </div>
+      <div>
+        <input type="text" class="form-control" placeholder="Your answer" id="entry.1277414663" name="entry.1277414663" required>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.2061735377">Phone Number <span class="req">*</span></label>
+      </div>
+      <div>
+        <input type="text" class="form-control" placeholder="Your answer" id="entry.2061735377" name="entry.2061735377" required>
+      </div>
+    </div>
+  </div>
+  <div class="row form-subheader">
+    <div class="col-xs-12">
+      <div class="form-subheader-container" role="heading">
+        <div>Scope of Work</div>
+      </div>
+      <div class="form-subheader-triangle">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 14 10" preserveAspectRatio="none">
+          <polygon class="freebirdSolidFill" points="0,0 13,0 0,13"></polygon>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.423030335">What are the two most important aspects of the development effort? <span class="req">*</span></label>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.423030335' value="Development costs" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Development costs</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.423030335' value="Time to market" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Time to market</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.423030335' value="Quality product meeting all requirements" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Quality product meeting all requirements</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.905578561">What is the budget for this development effort? <span class="req">*</span></label>
+        <p class="form-question-desc">It is very important for us to understand your budget constraints. For every project we do, we must ensure that our clients budget matches their expectations concerning the final product. Talking about the budget early and often helps to ensure a smooth development effort.</p>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn active form-control">
+          <input type="radio" name="entry.905578561" value="Less than $10,000" required><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Less than $10,000</span>
+        </label>
+        <label class="btn form-control">
+          <input type="radio" name="entry.905578561" value="More than $10,000 but less than $100,0000"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i><span> More than $10,000 but less than $100,0000</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.905578561" value="More than $100,000 but less than $1M"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than $100,000 but less than $1M</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.905578561" value="More than $1M"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than $1M</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.999538614">What is the target date to start selling the product? <span class="req">*</span></label>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn active form-control">
+          <input type="radio" name="entry.999538614" value="Less than 3 months from now" required><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Less than 3 months from now</span>
+        </label>
+        <label class="btn form-control">
+          <input type="radio" name="entry.999538614" value="Between 3 months and 6 months from now"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i><span> Between 3 months and 6 months from now</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.999538614" value="Between 6 months and 12 months from now"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Between 6 months and 12 months from now</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.999538614" value="More than $1M"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than 12 months from now</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.2076440457">What type of services do you require? <span class="req">*</span></label>
+        <p class="form-question-desc">Please check all that apply.</p>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="CTO and Product Management Consulting" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> CTO and Product Management Consulting</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Turn-key Product Development" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Turn-key Product Development</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Product Design" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Product Design</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Mechanical Engineering" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Mechanical Engineering</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Electrical Engineering" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Electrical Engineering</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Firmware Engineering" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Firmware Engineering</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.2076440457' value="Software Development" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Software Development</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row form-subheader">
+    <div class="col-xs-12">
+      <div class="form-subheader-container" role="heading">
+        <div>Product Market Information</div>
+      </div>
+      <div class="form-subheader-triangle">
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 14 10" preserveAspectRatio="none">
+          <polygon class="freebirdSolidFill" points="0,0 13,0 0,13"></polygon>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.1505721761">In which industry will the product be sold? <span class="req">*</span></label>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" value="Consumer" required><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Consumer</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" value="Industrial"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Industrial</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" value="Business/Commercial"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Business/Commercial</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" value="Automotive"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Automotive</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" value="Medical"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Medical</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1505721761" id="entry.1505721761.other-option" value="__other_option__"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Other <input type="text" class="form-control other" id="entry.1505721761.other_option_response" name="entry.1505721761.other_option_response"></span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.2141793368">Do you currently sell products in this industry? <span class="req">*</span></label>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn active form-control">
+          <input type="radio" name="entry.2141793368" value="Yes" required><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Yes</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.2141793368" value="No, we sell products in a different industry"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> No, we sell products in a different industry</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.2141793368" value="No, this is our first product"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> No, this is our first product</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.1227325807">What is your target market size for the first year?  <span class="req">*</span></label>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1227325807" value="Less than 1,000 units" required><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> Less than 1,000 units</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1227325807" value="More than 1000 units but less than 10,000 units"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than 1000 units but less than 10,000 units</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1227325807" value="More than 10,000 units but less than 100,000 units"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than 10,000 units but less than 100,000 units</span>
+        </label>
+        <label class="btn active form-control">
+          <input type="radio" name="entry.1227325807" value="More than 10,000 units"><i class="fa fa-circle-o fa-big"></i><i class="fa fa-dot-circle-o fa-big"></i> <span> More than 10,000 units</span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div>
+        <label for="entry.1799556590">What technologies are required for your product? <span class="req">*</span></label>
+        <p class="form-question-desc">Please check all that apply.</p>
+      </div>
+      <div class="btn-group btn-group-vertical" data-toggle="buttons">
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Bluetooth" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Bluetooth</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Wifi" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Wifi</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Ethernet" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Ethernet</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="USB" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> USB</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Audio" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Audio</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Zigbee, Z-Wave or Other RF Protocol" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Zigbee, Z-Wave or Other RF Protocol</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Battery Powered" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Battery Powered</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Embedded Microcontroller Software" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Embedded Microcontroller Software</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Embedded Software on Linux" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Embedded Software on Linux</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Mobile Software" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Mobile Software</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Desktop Software" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Desktop Software</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' value="Web Software" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Web Software</span>
+        </label>
+        <label class="btn form-control">
+          <input type="checkbox" name='entry.1799556590' id="entry.1799556590.other-option" value="__other_option__" required><i class="fa fa-square-o fa-big"></i><i class="fa fa-check-square fa-big"></i> <span> Other <input type="text" class="form-control other" id="entry.1799556590.other_option_response" name="entry.1799556590.other_option_response"></span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+    	<div class="form-group">	
+				<button type="submit" class="btn btn-lg btn-success submitbtn">Submit</button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/about.md
+++ b/about.md
@@ -49,7 +49,7 @@ sections:
 				<p>We are moving to a new location soon.  Stay tuned.</p>
 				</div>
 				<p>
-				<a class="btn btn-lg btn-success" href="https://goo.gl/forms/JDm6yKoL0SMZUWIl2" target="_blank">Request a Free Consultation</a>
+				<a class="btn btn-lg btn-success" href="{{ BASE_PATH }}/contact-us">Request a Free Consultation</a>
 				</p>
 			</div>
 			<div class="col-md-6">

--- a/assets/themes/twitter/css/style.css
+++ b/assets/themes/twitter/css/style.css
@@ -65,7 +65,7 @@
 
 /******************************************************************************
 /* Form Styling */
-#ciForm {
+#ciForm, #cuForm {
   border: 1px solid #c8c8c8;
   border-radius: 5px;
   padding: 20px;
@@ -145,7 +145,7 @@ label:hover input[type="radio"] ~ i.fa {
   background-color: #ffebee;
 }
 
-#ciForm .row {
+#ciForm .row, #cuForm .row {
     margin-bottom: 10px;
     padding-bottom: 10px;
     padding-top: 10px;
@@ -154,4 +154,35 @@ label:hover input[type="radio"] ~ i.fa {
 .error-message {
     color: red;
     padding-top: 10px;
+}
+
+.form-subheader {
+  margin-left: -35px;
+}
+
+.form-subheader-container {
+  background-color: #344555;
+  padding: 10px 0px 10px 20px;
+  color: #fff;
+  float: left;
+}
+
+.form-subheader-triangle {
+  float:left
+}
+
+.form-subheader-triangle svg {
+  height: 100%;
+  overflow: hidden;
+  position: absolute;
+}
+
+.form-subheader-triangle svg polygon {
+  fill: #344555;
+  stroke: #344555;
+  stroke-width: 1;
+}
+
+.form-question-desc {
+  font-size: 12px;
 }

--- a/assets/themes/twitter/js/application.js
+++ b/assets/themes/twitter/js/application.js
@@ -32,6 +32,26 @@ $(function () {
     return false;
   });
 
+  // Capture Collaborative Interest Form Submit
+  $("#cuForm").submit(function() {
+
+    var pgHistory = '';
+
+    pgHistory = "&pageHistory=0"
+
+    $.ajax({
+      type: 'POST',
+      url: "https://docs.google.com/forms/d/e/1FAIpQLSc4sHW3OhJDocWVc3pEnzO_llQBZAd_KC9UpbEywY_1HUIFGw/formResponse",
+      data: $("#cuForm").serialize().replace(/[^&]+=&/g, '').replace(/&[^&]+=$/g, '') + pgHistory,
+      complete: function() {
+        window.location.href="/thank-you-contact/";
+      }
+    });
+
+    // prevent submitting form again
+    return false;
+  });
+
 	// Display/Hide ember or Provider form fields depending on selection
   $("input[name$='entry.182110896']").on( "change", function() {
     var rdVal = $(this).val();
@@ -79,6 +99,7 @@ function replaceValidationUI( form ) {
       var invalidFields = form.querySelectorAll( ":invalid" ),
           errorMessages = form.querySelectorAll( ".error-message" ),
           radioError = false;
+          radioErrorArr = [];
           parent;
 
         // Remove any existing messages
@@ -86,7 +107,15 @@ function replaceValidationUI( form ) {
         $('.invalid-row').removeClass('invalid-row');
 
         for ( var i = 0; i < invalidFields.length; i++ ) {
+          radioError = false;
           if (invalidFields[ i ].type == "radio") {
+            for (var j = 0; j < radioErrorArr.length; j++) {
+              if (radioErrorArr[j] == invalidFields[i].name) {
+                radioError = true;
+                break;
+              }
+            }
+            radioErrorArr.push(invalidFields[i].name);
             if (!radioError) {
               parent = invalidFields[ i ].parentNode.parentNode;
               parent.insertAdjacentHTML( "beforeend", "<div class='error-message'>" + 
@@ -94,6 +123,27 @@ function replaceValidationUI( form ) {
                   "</div>" );
               $(invalidFields[ i ].parentNode.parentNode.parentNode.parentNode).addClass("invalid-row");  
               radioError = true;
+            }
+          } else if (invalidFields[ i ].type == "checkbox") {
+            var cbx_group = $("input:checkbox[name='" + invalidFields[i].name + "']");
+            if (!cbx_group.is(":checked")) {
+              cbx_group.attr('required', 'required');
+              for (var j = 0; j < radioErrorArr.length; j++) {
+                if (radioErrorArr[j] == invalidFields[i].name) {
+                  radioError = true;
+                  break;
+                }
+              }
+              radioErrorArr.push(invalidFields[i].name);
+              if (!radioError) {
+                parent = invalidFields[ i ].parentNode.parentNode;
+                parent.insertAdjacentHTML( "beforeend", "<div class='error-message'>" + 
+                    invalidFields[ i ].validationMessage +
+                    "</div>" );
+                $(invalidFields[ i ].parentNode.parentNode.parentNode.parentNode).addClass("invalid-row");
+              }
+            } else {
+              cbx_group.removeAttr('required');
             }
           } else {
             parent = invalidFields[ i ].parentNode;

--- a/assets/themes/twitter/js/application.js
+++ b/assets/themes/twitter/js/application.js
@@ -32,7 +32,7 @@ $(function () {
     return false;
   });
 
-  // Capture Collaborative Interest Form Submit
+  // Contact Us Form Submit
   $("#cuForm").submit(function() {
 
     var pgHistory = '';

--- a/contact-us.md
+++ b/contact-us.md
@@ -1,0 +1,34 @@
+---
+layout: homepage
+title: Contact Form
+tagline: Contact Form
+sections:
+ intro: New Client
+ brief: Contact Form
+ icon: fa fa-envelope-square fa-5x
+---
+
+<div style="background: #344555; color: #fff;">
+<div class="container">
+	<div class="row" style="margin-top: 50px; margin-bottom: 50px;">
+		<div class="col-md-3 text-center">
+			<h1><i class="{{ page.sections['icon'] }}"></i></h1>
+		</div>
+		<div class="col-md-9">
+			<h1><b>{{ page.sections['intro'] }}</b></h1>
+			<h3>{{ page.sections['brief'] }}</h3>
+		</div>
+	</div>
+</div>
+</div>
+
+<section class="content-section" style="background-color: rgb(232, 234, 246);">
+	<div class="container">
+		<h2 class="section-heading">{{ page.form_title }}</h2>
+		<div class="row">
+			<div class="col-md-12 col-lg-offset-3 col-lg-6">
+        {% include JB/contact-us-form.html %}
+			</div>
+		</div>
+	</div>
+</section>

--- a/contact-us.md
+++ b/contact-us.md
@@ -22,7 +22,7 @@ sections:
 </div>
 </div>
 
-<section class="content-section" style="background-color: rgb(232, 234, 246);">
+<section class="content-section">
 	<div class="container">
 		<h2 class="section-heading">{{ page.form_title }}</h2>
 		<div class="row">

--- a/index.md
+++ b/index.md
@@ -63,7 +63,7 @@ $(function () {
 		<p>
 			<center>
 				<a class="btn btn-lg btn-info" href="{{ BASE_PATH }}/services">Learn More</a>
-				<a class="btn btn-lg btn-info" href="https://goo.gl/forms/JDm6yKoL0SMZUWIl2" target="_blank">Contact Us</a>
+				<a class="btn btn-lg btn-info" href="{{ BASE_PATH }}/contact-us">Contact Us</a>
 			</center>
 		</p>
 		<p></p>

--- a/services.md
+++ b/services.md
@@ -26,7 +26,7 @@ sections:
 	<div class="container" style="padding-top: 20px; padding-bottom: 20px;">
 		<p>
 			<center>
-				<a class="btn btn-lg btn-success" href="https://goo.gl/forms/JDm6yKoL0SMZUWIl2" target="_blank">Request a Free Consultation</a>
+				<a class="btn btn-lg btn-success" href="{{ BASE_PATH }}/contact-us">Request a Free Consultation</a>
 			</center>
 
 		</p>

--- a/thank-you-contact.md
+++ b/thank-you-contact.md
@@ -1,11 +1,11 @@
 ---
 layout: homepage
 title: Contact Form Thank You
-tagline: Contact Form
+tagline: Contact Form Thank You
 sections:
  intro: New Client
  brief: Contact Form
- icon: fa fa-envelope-square fa-5x
+ icon: fa fa-check-square fa-5x
 ---
 
 <div style="background: #344555; color: #fff;">
@@ -25,7 +25,8 @@ sections:
 <section class="content-section">
 	<div class="container">
 		<h2 class="section-heading">{{ page.form_title }}</h2>
-    <div class="alert alert-success" role="alert"> Thank you for contacting Stratify Labs. You should hear back from us in the next 24 hours.</div>
+    	<div class="alert alert-success" role="alert"> Your information was submitted successfully.</div>
+    	<p>Thank you for contacting Stratify Labs. You should hear back from us in the next 24 hours.</p>
 	</div>
 </section>
 

--- a/thank-you-contact.md
+++ b/thank-you-contact.md
@@ -1,0 +1,32 @@
+---
+layout: homepage
+title: Contact Form Thank You
+tagline: Contact Form
+sections:
+ intro: New Client
+ brief: Contact Form
+ icon: fa fa-envelope-square fa-5x
+---
+
+<div style="background: #344555; color: #fff;">
+<div class="container">
+	<div class="row" style="margin-top: 50px; margin-bottom: 50px;">
+		<div class="col-md-3 text-center">
+			<h1><i class="{{ page.sections['icon'] }}"></i></h1>
+		</div>
+		<div class="col-md-9">
+			<h1><b>{{ page.sections['intro'] }}</b></h1>
+			<h3>{{ page.sections['brief'] }}</h3>
+		</div>
+	</div>
+</div>
+</div>
+
+<section class="content-section">
+	<div class="container">
+		<h2 class="section-heading">{{ page.form_title }}</h2>
+    <div class="alert alert-success" role="alert"> Thank you for contacting Stratify Labs. You should hear back from us in the next 24 hours.</div>
+	</div>
+</section>
+
+{% include JB/analytics-providers/google-adwords.html %}


### PR DESCRIPTION
This pull request contains the Contact Us form's migration from google forms so that it is now natively included in the Stratify Labs website.

Similar to #1, in order to complete this task:
- [X] - started with just creating the HTML form within an include file in the repo at `_includes/JB/contact-us-form.html`.  The include was then insterted into a stand alone page (`contact-us.md`).
- [X] - some additional css was added in `assets/themes/twitter/css/style.css` specific for the contact us form.
- [X] - also framed out the thank you page at `thank-you-contact.md`.  We could conceivably combine the `thank-you.md` and `thank-you-contact.md` page or at least setup a separate "thank-you" page layout to reduce redundant code, but went with just basically replicating the `thank-you.md` page for now.  If we want to go with a different approach to reduce redundancy we can adjust.
- [X] - some additional js changes were necessary for the new form submit and validation.

Finally, I updated all the previous google form links within the site to now point to the new native contact us form at `/contact-us` and modified the links to not open in a new tab anymore.